### PR TITLE
A developer only feature which enables saving and loading of github cached data to disk

### DIFF
--- a/app/uk/gov/hmrc/teamsandrepositories/RepoType.scala
+++ b/app/uk/gov/hmrc/teamsandrepositories/RepoType.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.teamsandrepositories
 
-import play.api.libs.json.{JsString, JsResult, JsValue, Format}
+import play.api.libs.json._
 
 object RepoType extends Enumeration {
 
@@ -25,7 +25,18 @@ object RepoType extends Enumeration {
   val Deployable, Library, Other = Value
 
   implicit val repoType = new Format[RepoType] {
-    override def reads(json: JsValue): JsResult[RepoType] = ???
+
+    override def reads(json: JsValue): JsResult[RepoType] = json match {
+      case JsString(s) => {
+        try {
+          JsSuccess(RepoType.withName(s))
+        } catch {
+          case _: NoSuchElementException => JsError(s"Enumeration expected of type: '${RepoType.getClass}', but it does not appear to contain the value: '$s'")
+        }
+      }
+      case _ => JsError("String value expected")
+    }
+
 
     override def writes(o: RepoType): JsValue = JsString(o.toString)
   }

--- a/app/uk/gov/hmrc/teamsandrepositories/RepositoryDataSource.scala
+++ b/app/uk/gov/hmrc/teamsandrepositories/RepositoryDataSource.scala
@@ -74,7 +74,7 @@ class GithubV3RepositoryDataSource(val gh: GithubApiClient,
     exponentialRetry(retries, initialDuration) {
       gh.getTeamsForOrganisation(organisation.login).flatMap { teams =>
         Future.sequence(for {
-          team <- teams if !githubConfig.hiddenTeams.contains(team.name) && team.name == "CCA"
+          team <- teams if !githubConfig.hiddenTeams.contains(team.name)
         } yield mapTeam(organisation, team))
       }
     }

--- a/app/uk/gov/hmrc/teamsandrepositories/RepositoryDataSource.scala
+++ b/app/uk/gov/hmrc/teamsandrepositories/RepositoryDataSource.scala
@@ -169,14 +169,16 @@ class CachingRepositoryDataSource[T](
                                       akkaSystem: ActorSystem,
                                       cacheConfig: CacheConfig,
                                       dataSource: () => Future[T],
-                                      timeStamp: () => LocalDateTime) {
+                                      timeStamp: () => LocalDateTime,
+                                      initialLoad: Boolean = true) {
 
-  private var cachedData: Option[CachedResult[T]] = None
+  var cachedData: Option[CachedResult[T]] = None
   private val initialPromise = Promise[CachedResult[T]]()
 
   import ExecutionContext.Implicits._
 
-  dataUpdate()
+  if(initialLoad)
+    dataUpdate()
 
   private def fromSource = {
     dataSource().map { d => {

--- a/app/uk/gov/hmrc/teamsandrepositories/TeamRepositoryWrapper.scala
+++ b/app/uk/gov/hmrc/teamsandrepositories/TeamRepositoryWrapper.scala
@@ -73,6 +73,23 @@ object TeamRepositoryWrapper {
       }
     }
 
+    def asTeamRepositoryDetailsList(teamName: String): Option[Map[RepoType.RepoType, List[RepositoryDisplayDetails]]] = {
+      val decodedTeamName = URLDecoder.decode(teamName, "UTF-8")
+      teamRepos.find(_.teamName == decodedTeamName).map { t =>
+
+        RepoType.values.foldLeft(Map.empty[RepoType.Value, List[RepositoryDisplayDetails]]) { case (m, rtype) =>
+          m + (
+            rtype ->
+              extractRepositoryGroupForType(rtype, t.repositories)
+                .map(r => RepositoryDisplayDetails(r.name, r.createdDate, r.lastActiveDate))
+                .groupBy(_.name).map(_._2.head).toList
+                .sortBy(_.name.toUpperCase)
+            )
+        }
+
+      }
+    }
+
     private case class RepositoryToTeam(repositoryName: String, teamName: String)
 
     def asRepositoryTeamNameList(): Map[String, Seq[String]] = {

--- a/app/uk/gov/hmrc/teamsandrepositories/TeamsRepositoriesController.scala
+++ b/app/uk/gov/hmrc/teamsandrepositories/TeamsRepositoriesController.scala
@@ -69,6 +69,7 @@ with UrlTemplatesProvider {
 
   private def dataLoader: () => Future[Seq[TeamRepositories]] = new CompositeRepositoryDataSource(List(enterpriseTeamsRepositoryDataSource, openTeamsRepositoryDataSource)).getTeamRepoMapping _
 
+
   protected val dataSource: CachingRepositoryDataSource[Seq[TeamRepositories]] = new CachingRepositoryDataSource[Seq[TeamRepositories]](
     Akka.system(), CacheConfig,
     dataLoader,

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,8 +1,11 @@
 # microservice specific routes
 
+GET         /api/save                      uk.gov.hmrc.teamsandrepositories.TeamsRepositoriesController.save
+GET         /api/load                      uk.gov.hmrc.teamsandrepositories.TeamsRepositoriesController.load
 GET         /api/teams                      uk.gov.hmrc.teamsandrepositories.TeamsRepositoriesController.teams
 GET         /api/teams/:team                uk.gov.hmrc.teamsandrepositories.TeamsRepositoriesController.repositoriesByTeam(team)
 GET         /api/cache/reload               uk.gov.hmrc.teamsandrepositories.TeamsRepositoriesController.reloadCache
 GET         /api/services                   uk.gov.hmrc.teamsandrepositories.TeamsRepositoriesController.services
 GET         /api/libraries                  uk.gov.hmrc.teamsandrepositories.TeamsRepositoriesController.libraries
 GET         /api/repositories/:name         uk.gov.hmrc.teamsandrepositories.TeamsRepositoriesController.repositoryDetails(name)
+

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -178,4 +178,4 @@ url-templates {
 
 }
 
-initialiseCache = false
+github.integration.enabled = true

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -175,4 +175,7 @@ url-templates {
         url: "http://ser2/$name"
       }]
     }]
+
 }
+
+initialiseCache = false

--- a/project/MicroServiceBuild.scala
+++ b/project/MicroServiceBuild.scala
@@ -18,7 +18,7 @@ private object AppDependencies {
 
   import play.core.PlayVersion.current
 
-  private val microserviceBootstrapVersion = "5.1.0"
+  private val microserviceBootstrapVersion = "5.8.0"
   private val playAuthVersion = "4.0.0"
   private val playHealthVersion = "2.0.0"
   private val playJsonLoggerVersion = "3.0.0"


### PR DESCRIPTION
Been experiencing too many rate limiting issues while working on this project. This is an attempt to address this issue by allowing the developer to save the data to disk by calling:
GET http://localhost:9011/api/save?file=%2Ftmp%2Ffilename.data

(saves the file to /tmp/filename.data)

and loading the data by calling
GET http://localhost:9011/api/load?file=%2Ftmp%2Ffilename.data

(loads the file from /tmp/filename.data)