### PR TITLE
A developer only feature which enables saving and loading of github cached data to disk

### DIFF
--- a/app/uk/gov/hmrc/teamsandrepositories/RepoType.scala
+++ b/app/uk/gov/hmrc/teamsandrepositories/RepoType.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.teamsandrepositories
 
-import play.api.libs.json.{JsString, JsResult, JsValue, Format}
+import play.api.libs.json._
 
 object RepoType extends Enumeration {
 
@@ -25,7 +25,18 @@ object RepoType extends Enumeration {
   val Deployable, Library, Other = Value
 
   implicit val repoType = new Format[RepoType] {
-    override def reads(json: JsValue): JsResult[RepoType] = ???
+
+    override def reads(json: JsValue): JsResult[RepoType] = json match {
+      case JsString(s) => {
+        try {
+          JsSuccess(RepoType.withName(s))
+        } catch {
+          case _: NoSuchElementException => JsError(s"Enumeration expected of type: '${RepoType.getClass}', but it does not appear to contain the value: '$s'")
+        }
+      }
+      case _ => JsError("String value expected")
+    }
+
 
     override def writes(o: RepoType): JsValue = JsString(o.toString)
   }

--- a/app/uk/gov/hmrc/teamsandrepositories/RepositoryDataSource.scala
+++ b/app/uk/gov/hmrc/teamsandrepositories/RepositoryDataSource.scala
@@ -74,7 +74,7 @@ class GithubV3RepositoryDataSource(val gh: GithubApiClient,
     exponentialRetry(retries, initialDuration) {
       gh.getTeamsForOrganisation(organisation.login).flatMap { teams =>
         Future.sequence(for {
-          team <- teams if !githubConfig.hiddenTeams.contains(team.name) && team.name == "CCA"
+          team <- teams if !githubConfig.hiddenTeams.contains(team.name)
         } yield mapTeam(organisation, team))
       }
     }

--- a/app/uk/gov/hmrc/teamsandrepositories/RepositoryDataSource.scala
+++ b/app/uk/gov/hmrc/teamsandrepositories/RepositoryDataSource.scala
@@ -169,14 +169,16 @@ class CachingRepositoryDataSource[T](
                                       akkaSystem: ActorSystem,
                                       cacheConfig: CacheConfig,
                                       dataSource: () => Future[T],
-                                      timeStamp: () => LocalDateTime) {
+                                      timeStamp: () => LocalDateTime,
+                                      initialLoad: Boolean = true) {
 
-  private var cachedData: Option[CachedResult[T]] = None
+  var cachedData: Option[CachedResult[T]] = None
   private val initialPromise = Promise[CachedResult[T]]()
 
   import ExecutionContext.Implicits._
 
-  dataUpdate()
+  if(initialLoad)
+    dataUpdate()
 
   private def fromSource = {
     dataSource().map { d => {

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,8 +1,11 @@
 # microservice specific routes
 
+GET         /api/save                      uk.gov.hmrc.teamsandrepositories.TeamsRepositoriesController.save
+GET         /api/load                      uk.gov.hmrc.teamsandrepositories.TeamsRepositoriesController.load
 GET         /api/teams                      uk.gov.hmrc.teamsandrepositories.TeamsRepositoriesController.teams
 GET         /api/teams/:team                uk.gov.hmrc.teamsandrepositories.TeamsRepositoriesController.repositoriesByTeam(team)
 GET         /api/cache/reload               uk.gov.hmrc.teamsandrepositories.TeamsRepositoriesController.reloadCache
 GET         /api/services                   uk.gov.hmrc.teamsandrepositories.TeamsRepositoriesController.services
 GET         /api/libraries                  uk.gov.hmrc.teamsandrepositories.TeamsRepositoriesController.libraries
 GET         /api/repositories/:name         uk.gov.hmrc.teamsandrepositories.TeamsRepositoriesController.repositoryDetails(name)
+

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -178,4 +178,4 @@ url-templates {
 
 }
 
-initialiseCache = false
+github.integration.enabled = true

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -175,4 +175,7 @@ url-templates {
         url: "http://ser2/$name"
       }]
     }]
+
 }
+
+initialiseCache = false

--- a/project/MicroServiceBuild.scala
+++ b/project/MicroServiceBuild.scala
@@ -18,7 +18,7 @@ private object AppDependencies {
 
   import play.core.PlayVersion.current
 
-  private val microserviceBootstrapVersion = "5.1.0"
+  private val microserviceBootstrapVersion = "5.8.0"
   private val playAuthVersion = "4.0.0"
   private val playHealthVersion = "2.0.0"
   private val playJsonLoggerVersion = "3.0.0"

--- a/test/uk/gov/hmrc/teamsandrepositories/TeamsServicesControllerSpec.scala
+++ b/test/uk/gov/hmrc/teamsandrepositories/TeamsServicesControllerSpec.scala
@@ -36,17 +36,18 @@ class TeamsServicesControllerSpec extends PlaySpec with MockitoSugar with Result
   val timestamp = LocalDateTime.of(2016, 4, 5, 12, 57, 10)
 
   private val now = new Date().getTime
-  private val createdDateForDeployable1 = 1011111001l
-  private val createdDateForDeployable2 = 10111110012l
-  private val createdDateForDeployable3 = 10111110013l
-  private val lastActiveDateForDeployable1 = 10111110014l
-  private val lastActiveDateForDeployable2 = 10111110015l
-  private val lastActiveDateForDeployable3 = 10111110016l
 
-  private val createdDateForLib1 = 10111110017l
-  private val createdDateForLib2 = 10111110017l
-  private val lastActiveDateForLib1 = 10111110020l
-  private val lastActiveDateForLib2 = 10111110021l
+  private val createdDateForDeployable1 = 1
+  private val createdDateForDeployable2 = 2
+  private val createdDateForDeployable3 = 3
+  private val createdDateForLib1 = 4
+  private val createdDateForLib2 = 5
+
+  private val lastActiveDateForDeployable1 = 10
+  private val lastActiveDateForDeployable2 = 20
+  private val lastActiveDateForDeployable3 = 30
+  private val lastActiveDateForLib1 = 40
+  private val lastActiveDateForLib2 = 50
 
 
   def controllerWithData(data: CachedResult[Seq[TeamRepositories]]) = {


### PR DESCRIPTION
Been experiencing too many rate limiting issues while working on this project. This is an attempt to address this issue by allowing the developer to save the data to disk by calling:
GET http://localhost:9011/api/save?file=%2Ftmp%2Ffilename.data

(saves the file to /tmp/filename.data)

and loading the data by calling
GET http://localhost:9011/api/load?file=%2Ftmp%2Ffilename.data

(loads the file from /tmp/filename.data)