### PR TITLE
Include repositories without teams

### DIFF
--- a/app/uk/gov/hmrc/teamsandrepositories/persitence/model/TeamRepositories.scala
+++ b/app/uk/gov/hmrc/teamsandrepositories/persitence/model/TeamRepositories.scala
@@ -2,13 +2,11 @@ package uk.gov.hmrc.teamsandrepositories.persitence.model
 
 import java.net.URLDecoder
 import java.time.{LocalDateTime, ZoneOffset}
-
 import play.api.libs.json._
 import uk.gov.hmrc.teamsandrepositories
 import uk.gov.hmrc.teamsandrepositories.RepoType.RepoType
 import uk.gov.hmrc.teamsandrepositories._
 import uk.gov.hmrc.teamsandrepositories.config.UrlTemplates
-import uk.gov.hmrc.teamsandrepositories.controller.model.RepositoryDetails.determineLanguage
 import uk.gov.hmrc.teamsandrepositories.controller.model.{Repository, RepositoryDetails, Team}
 
 case class TeamRepositories(teamName: String, repositories: List[GitRepository], updateDate: Long)
@@ -67,10 +65,12 @@ object TeamRepositories {
                   repo.createdAt,
                   repo.lastUpdatedAt,
                   repo.repoType,
-                  repoNameToTeamNamesLookup.getOrElse(repo.name, Seq("TEAM_UNKNOWN"))))
+                  repoNameToTeamNamesLookup.getOrElse(repo.name, Seq(TEAM_UNKNOWN))))
           ))
     }
   }
+
+  val TEAM_UNKNOWN = "TEAM_UNKNOWN"
 
   implicit val localDateTimeRead: Reads[LocalDateTime] =
     __.read[Long].map { dateTime =>
@@ -134,10 +134,13 @@ object TeamRepositories {
         GitRepository.repoGroupToRepositoryDetails(
           GitRepository.primaryRepoType(repos.toSeq),
           repos.toSeq,
-          teams.toSeq.sorted,
+          dontShowUnknownTeam(teams.toSeq.sorted),
           ciUrlTemplates)
       case _ => None
     }
+
+  private def dontShowUnknownTeam(teams: Seq[String]): Seq[String] =
+    teams.filterNot(_ == TEAM_UNKNOWN)
 
   def getTeamRepositoryNameList(
     teamRepos: Seq[TeamRepositories],

--- a/app/uk/gov/hmrc/teamsandrepositories/services/GithubV3RepositoryDataSource.scala
+++ b/app/uk/gov/hmrc/teamsandrepositories/services/GithubV3RepositoryDataSource.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.teamsandrepositories.services
 
 import com.codahale.metrics.MetricRegistry
+import org.eclipse.egit.github.core.Repository
 import org.yaml.snakeyaml.Yaml
 import play.api.Logger
 import play.api.libs.json._
@@ -26,10 +27,10 @@ import uk.gov.hmrc.teamsandrepositories.config.GithubConfig
 import uk.gov.hmrc.teamsandrepositories.helpers.RetryStrategy._
 import uk.gov.hmrc.teamsandrepositories.persitence.model.TeamRepositories
 import uk.gov.hmrc.teamsandrepositories.{GitRepository, RepoType}
-
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.language.postfixOps
 import scala.util.{Failure, Success, Try}
+import collection.JavaConverters._
 
 case class TeamNamesTuple(ghNames: Option[Future[Set[String]]] = None, mongoNames: Option[Future[Set[String]]] = None)
 
@@ -115,6 +116,29 @@ class GithubV3RepositoryDataSource(
         throw e
     }
   }
+
+  def getAllRepositories(implicit ec: ExecutionContext): Future[List[GitRepository]] =
+    gh.getOrganisations.map { orgs =>
+      orgs.flatMap { org =>
+        gh.repositoryService
+          .getOrgRepositories(org.login)
+          .asScala
+          .map(toGitRepository)
+          .toList
+      }
+    }
+
+  private def toGitRepository(r: Repository): GitRepository =
+    GitRepository(
+      name           = r.getName,
+      description    = Option(r.getDescription).getOrElse(""),
+      url            = r.getHtmlUrl,
+      createdDate    = r.getCreatedAt.getTime,
+      lastActiveDate = r.getPushedAt.getTime,
+      isInternal     = isInternal,
+      isPrivate      = r.isPrivate,
+      language       = Option(r.getLanguage)
+    )
 
   def getRepositoryDetailsFromGithub(organisation: GhOrganisation, repository: GhRepository): Future[GitRepository] =
     for {

--- a/app/uk/gov/hmrc/teamsandrepositories/services/GithubV3RepositoryDataSource.scala
+++ b/app/uk/gov/hmrc/teamsandrepositories/services/GithubV3RepositoryDataSource.scala
@@ -102,7 +102,7 @@ class GithubV3RepositoryDataSource(
       } flatMap { repos =>
         Future
           .sequence(for {
-            repo <- repos; if !repo.fork && !githubConfig.hiddenRepositories.contains(repo.name)
+            repo <- repos; if !githubConfig.hiddenRepositories.contains(repo.name)
           } yield {
             mapRepository(organisation, team, repo, persistedTeams, fullRefreshWithHighApiCall)
           })

--- a/project/MicroService.scala
+++ b/project/MicroService.scala
@@ -1,3 +1,4 @@
+import play.sbt.PlayImport.PlayKeys
 import play.sbt.PlayScala
 import play.sbt.routes.RoutesKeys.{routesGenerator, _}
 import sbt.Keys._
@@ -19,6 +20,7 @@ trait MicroService {
   lazy val microservice = Project(appName, file("."))
     .enablePlugins(Seq(PlayScala) ++ plugins: _*)
     .settings(playSettings: _*)
+    .settings(PlayKeys.playDefaultPort := 9015)
     .settings(scalaSettings: _*)
     .settings(publishingSettings: _*)
     .settings(defaultSettings(): _*)

--- a/test/uk/gov/hmrc/teamsandrepositories/GitCompositeDataSourceSpec.scala
+++ b/test/uk/gov/hmrc/teamsandrepositories/GitCompositeDataSourceSpec.scala
@@ -1,27 +1,24 @@
 package uk.gov.hmrc.teamsandrepositories
 
-import java.util.Date
-
 import com.codahale.metrics.{Counter, MetricRegistry}
 import com.kenshoo.play.metrics.Metrics
+import java.util.Date
+import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
-import org.mockito.{ArgumentMatchers, Mockito}
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mock.MockitoSugar
 import org.scalatestplus.play.OneAppPerSuite
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
+import scala.concurrent.Future
 import uk.gov.hmrc.githubclient.{GitApiConfig, GithubApiClient}
 import uk.gov.hmrc.teamsandrepositories.config.GithubConfig
-import uk.gov.hmrc.teamsandrepositories.persitence.{MongoConnector, TeamsAndReposPersister}
 import uk.gov.hmrc.teamsandrepositories.persitence.model.TeamRepositories
+import uk.gov.hmrc.teamsandrepositories.persitence.{MongoConnector, TeamsAndReposPersister}
 import uk.gov.hmrc.teamsandrepositories.services.{GitCompositeDataSource, GithubApiClientDecorator, GithubV3RepositoryDataSource, Timestamper}
-
-import scala.concurrent.Future
-import scala.concurrent.Future.successful
 
 class GitCompositeDataSourceSpec
     extends FunSpec

--- a/test/uk/gov/hmrc/teamsandrepositories/GithubV3RepositoryDataSourceSpec.scala
+++ b/test/uk/gov/hmrc/teamsandrepositories/GithubV3RepositoryDataSourceSpec.scala
@@ -122,37 +122,6 @@ class GithubV3RepositoryDataSourceSpec
 
   "Github v3 Data Source " should {
 
-    "Return a list of teams and repositories, filtering out forks" in new Setup {
-
-      private val hmrcOrg = GhOrganisation("HMRC", 1)
-
-      when(githubClient.getOrganisations(ec)).thenReturn(Future.successful(List(hmrcOrg)))
-      private val teamA = GhTeam("A", 1)
-
-      when(githubClient.getTeamsForOrganisation("HMRC")(ec)).thenReturn(Future.successful(List(teamA)))
-      when(githubClient.getReposForTeam(1)(ec)).thenReturn(Future.successful(List(
-        GhRepository("A_r", "some description", 1, "url_A", fork   = false, now, now, false, "Scala"),
-        GhRepository("A_r2", "some description", 5, "url_A2", fork = true, now, now, false, "Scala")
-      )))
-
-      val eventualTeamRepositories =
-        dataSource.mapTeam(hmrcOrg, teamA, persistedTeams = Future.successful(Nil), fullRefreshWithHighApiCall = false)
-      eventualTeamRepositories.futureValue shouldBe
-        TeamRepositories(
-          "A",
-          List(
-            GitRepository(
-              "A_r",
-              "some description",
-              "url_A",
-              now,
-              now,
-              digitalServiceName = None,
-              language           = Some("Scala"))),
-          timestampF())
-
-    }
-
     "Set internal = true if the DataSource is marked as internal" in new Setup {
 
       val internalDataSource =


### PR DESCRIPTION
- include repositories without teams
- don't filter out forked repos (if a repo belongs to hmrc organisation and we maintain it e.g. as a library the fact that it was once forked doesn't make a difference)