### PR TITLE
PLATOPS-1308 - updating repositories sequentially

### DIFF
--- a/app/uk/gov/hmrc/teamsandrepositories/services/PersistingService.scala
+++ b/app/uk/gov/hmrc/teamsandrepositories/services/PersistingService.scala
@@ -45,7 +45,8 @@ case class PersistingService @Inject()(
       gitOpenClient,
       timestamper.timestampF,
       defaultMetricsRegistry,
-      repositoriesToIgnore
+      repositoriesToIgnore,
+      futureHelpers
     )
 
   def persistTeamRepoMapping(implicit ec: ExecutionContext): Future[Seq[TeamRepositories]] = {


### PR DESCRIPTION
By loading all repositories of one team concurrently it is possible to trigger DOS protection on github.com. The error that github returns is "You have triggered an abuse detection mechanism. Please wait a few minutes before you try again."

This fix runs the repository updates sequentially.