### PR TITLE
BDOG 168 Service Page / Code and Build / CI Links Incorrect

### DIFF
--- a/app/uk/gov/hmrc/teamsandrepositories/controller/model/RepositoryDetails.scala
+++ b/app/uk/gov/hmrc/teamsandrepositories/controller/model/RepositoryDetails.scala
@@ -2,10 +2,11 @@ package uk.gov.hmrc.teamsandrepositories.controller.model
 
 import java.net.URI
 
+import play.api.Logger
 import uk.gov.hmrc.teamsandrepositories.config.UrlTemplates
 import uk.gov.hmrc.teamsandrepositories.{GitRepository, RepoType}
 
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
 case class Environment(name: String, services: Seq[Link])
 
@@ -72,8 +73,13 @@ object RepositoryDetails {
     linkDisplayName: String,
     jobTeamName: String,
     repoName: String): Option[Link] =
-    Try(
+    Try {
       new URI("https", "build.tax.service.gov.uk", s"/job/$jobTeamName/job/$repoName", null).toASCIIString
-    ).toOption.map(url => Link(linkName, linkDisplayName, url))
+    } match {
+      case Success(url) => Some(Link(linkName, linkDisplayName, url))
+      case Failure(throwable) =>
+        Logger.warn(s"Unable to create build ci url for teamName: $jobTeamName and repoName: $repoName", throwable)
+        None
+    }
 
 }

--- a/app/uk/gov/hmrc/teamsandrepositories/controller/model/RepositoryDetails.scala
+++ b/app/uk/gov/hmrc/teamsandrepositories/controller/model/RepositoryDetails.scala
@@ -1,7 +1,11 @@
 package uk.gov.hmrc.teamsandrepositories.controller.model
 
-import uk.gov.hmrc.teamsandrepositories.config.{UrlTemplate, UrlTemplates}
+import java.net.URI
+
+import uk.gov.hmrc.teamsandrepositories.config.UrlTemplates
 import uk.gov.hmrc.teamsandrepositories.{GitRepository, RepoType}
+
+import scala.util.Try
 
 case class Environment(name: String, services: Seq[Link])
 
@@ -37,18 +41,13 @@ object RepositoryDetails {
         language    = repo.language.getOrElse("")
       )
 
-    if (hasEnvironment(repo)) {
-      repoDetails.copy(ci = buildCiUrls(repo, urlTemplates), environments = buildEnvironmentUrls(repo, urlTemplates))
-    } else if (hasBuild(repo)) {
-      repoDetails.copy(ci = buildCiUrls(repo, urlTemplates))
-    } else {
-      repoDetails
+    repo.repoType match {
+      case RepoType.Service =>
+        repoDetails.copy(ci = buildCiUrls(repoDetails), environments = buildEnvironmentUrls(repo, urlTemplates))
+      case RepoType.Library => repoDetails.copy(ci = buildCiUrls(repoDetails))
+      case _                => repoDetails
     }
   }
-
-  private def hasEnvironment(repo: GitRepository): Boolean = repo.repoType == RepoType.Service
-
-  private def hasBuild(repo: GitRepository): Boolean = repo.repoType == RepoType.Library
 
   private def buildEnvironmentUrls(repository: GitRepository, urlTemplates: UrlTemplates): Seq[Environment] =
     urlTemplates.environments.map {
@@ -59,14 +58,22 @@ object RepositoryDetails {
         Environment(name, links)
     }.toSeq
 
-  private def buildCiUrls(repository: GitRepository, urlTemplates: UrlTemplates): List[Link] =
-    if (repository.isPrivate) {
-      buildUrls(repository, urlTemplates.ciClosed)
-    } else {
-      buildUrls(repository, urlTemplates.ciOpen)
-    }
+  private def buildCiUrls(repo: RepositoryDetails): Seq[Link] = repo.teamNames match {
+    case Seq(teamName) => buildCiUrl("Build", "Build", teamName, repo.name).toSeq
+    case teamNames =>
+      teamNames.flatMap(teamName => {
+        val name = s"$teamName Build"
+        buildCiUrl(name, name, teamName, repo.name)
+      })
+  }
 
-  private def buildUrls(repo: GitRepository, templates: Seq[UrlTemplate]) =
-    templates.map(t => Link(t.name, t.displayName, t.url(repo.name))).toList
+  private def buildCiUrl(
+    linkName: String,
+    linkDisplayName: String,
+    jobTeamName: String,
+    repoName: String): Option[Link] =
+    Try(
+      new URI("https", "build.tax.service.gov.uk", s"/job/$jobTeamName/job/$repoName", null).toASCIIString
+    ).toOption.map(url => Link(linkName, linkDisplayName, url))
 
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -110,28 +110,6 @@ microservice {
 }
 
 url-templates {
-  ci-closed = [
-    {
-      name: "closed1"
-      display-name: "closed 1"
-      url: "http://closed1/$name"
-    },
-    {
-      name: "closed2"
-      display-name: "closed 2"
-      url: "http://closed2/$name"
-    }]
-  ci-open = [
-    {
-      name: "open1"
-      display-name: "open 1"
-      url: "http://open1/$name"
-    },
-    {
-      name: "open2"
-      display-name: "open 2"
-      url: "http://open2/$name"
-    }]
   envrionments=[{
       name : "env1",
       services = [{

--- a/test/uk/gov/hmrc/teamsandrepositories/GitRepositorySpec.scala
+++ b/test/uk/gov/hmrc/teamsandrepositories/GitRepositorySpec.scala
@@ -82,7 +82,7 @@ class GitRepositorySpec extends WordSpec with Matchers with OptionValues {
       )
     }
 
-    "not create ci links for libraries belonging to no teams" in {
+    "not create ci links for libraries without a team" in {
       val repo =
         GitRepository(
           "a-library",
@@ -165,7 +165,7 @@ class GitRepositorySpec extends WordSpec with Matchers with OptionValues {
       )
     }
 
-    "not create ci links for services belonging to no teams" in {
+    "not create ci links for services without a team" in {
       val repo =
         GitRepository(
           "a-service",

--- a/test/uk/gov/hmrc/teamsandrepositories/GitRepositorySpec.scala
+++ b/test/uk/gov/hmrc/teamsandrepositories/GitRepositorySpec.scala
@@ -29,18 +29,6 @@ class GitRepositorySpec extends WordSpec with Matchers with OptionValues {
   val now = DateTimeUtils.now.getMillis
 
   val urlTemplates = UrlTemplates(
-    ciOpen = Seq(
-      UrlTemplate(
-        name        = "open1",
-        displayName = "open 1",
-        template    = "http://open/$name"
-      )),
-    ciClosed = Seq(
-      UrlTemplate(
-        name        = "closed1",
-        displayName = "closed 1",
-        template    = "http://closed/$name"
-      )),
     environments = ListMap(
       "env1" -> Seq(new UrlTemplate("log1", "log 1", "$name"), new UrlTemplate("mon1", "mon 1", "$name")),
       "env2" -> Seq(new UrlTemplate("log1", "log 1", "$name"))

--- a/test/uk/gov/hmrc/teamsandrepositories/GitRepositorySpec.scala
+++ b/test/uk/gov/hmrc/teamsandrepositories/GitRepositorySpec.scala
@@ -50,43 +50,7 @@ class GitRepositorySpec extends WordSpec with Matchers with OptionValues {
   def githubLink(url: String) = Link("github-com", "GitHub.com", url)
 
   "repoGroupToRepositoryDetails" should {
-    "create links for open libraries" in {
-      val repo =
-        GitRepository(
-          "a-library",
-          "Some Description",
-          "https://github.com/org/a-library",
-          now,
-          now,
-          repoType = RepoType.Library,
-          language = Some("Scala")
-        )
-
-      val repoDetails = RepositoryDetails.create(repo, Seq("teamName"), urlTemplates)
-
-      repoDetails.githubUrl shouldBe githubLink("https://github.com/org/a-library")
-      repoDetails.ci        shouldBe List(Link("open1", "open 1", "http://open/a-library"))
-    }
-
-    "create links for open services" in {
-      val repo =
-        GitRepository(
-          "a-frontend",
-          "Some Description",
-          "https://github.com/org/a-frontend",
-          now,
-          now,
-          repoType = RepoType.Service,
-          language = Some("Scala")
-        )
-
-      val repoDetails = RepositoryDetails.create(repo, Seq("teamName"), urlTemplates)
-
-      repoDetails.githubUrl shouldBe githubLink("https://github.com/org/a-frontend")
-      repoDetails.ci        shouldBe List(Link("open1", "open 1", "http://open/a-frontend"))
-    }
-
-    "create links for private libraries" in {
+    "create links for libraries" in {
       val repo =
         GitRepository(
           "a-library",
@@ -99,18 +63,82 @@ class GitRepositorySpec extends WordSpec with Matchers with OptionValues {
           language  = Some("Scala")
         )
 
-      val repoDetails = RepositoryDetails.create(repo, Seq("teamName"), urlTemplates)
+      val repoDetails = RepositoryDetails.create(repo, Seq("a-team"), urlTemplates)
 
       repoDetails.githubUrl shouldBe githubLink("https://github.com/org/a-library")
-      repoDetails.ci        shouldBe List(Link("closed1", "closed 1", "http://closed/a-library"))
+      repoDetails.ci        shouldBe List(Link("Build", "Build", "https://build.tax.service.gov.uk/job/a-team/job/a-library"))
     }
 
-    "create links for private services" in {
+    "create ci links for libraries belonging to multiple teams" in {
       val repo =
         GitRepository(
-          "a-frontend",
+          "a-library",
           "Some Description",
-          "https://github.com/org/a-frontend",
+          "https://github.com/org/a-library",
+          now,
+          now,
+          isPrivate = true,
+          repoType  = RepoType.Library,
+          language  = Some("Scala")
+        )
+
+      val repoDetails = RepositoryDetails.create(repo, Seq("a-team", "another-team"), urlTemplates)
+
+      repoDetails.githubUrl shouldBe githubLink("https://github.com/org/a-library")
+      repoDetails.ci shouldBe List(
+        Link("a-team Build", "a-team Build", "https://build.tax.service.gov.uk/job/a-team/job/a-library"),
+        Link(
+          "another-team Build",
+          "another-team Build",
+          "https://build.tax.service.gov.uk/job/another-team/job/a-library")
+      )
+    }
+
+    "not create ci links for libraries belonging to no teams" in {
+      val repo =
+        GitRepository(
+          "a-library",
+          "Some Description",
+          "https://github.com/org/a-library",
+          now,
+          now,
+          isPrivate = true,
+          repoType  = RepoType.Library,
+          language  = Some("Scala")
+        )
+
+      val repoDetails = RepositoryDetails.create(repo, Seq(), urlTemplates)
+
+      repoDetails.githubUrl shouldBe githubLink("https://github.com/org/a-library")
+      repoDetails.ci        shouldBe List()
+    }
+
+    "url encode ci links with spaces correctly" in {
+      val repo =
+        GitRepository(
+          "a-library",
+          "Some Description",
+          "https://github.com/org/a-library",
+          now,
+          now,
+          isPrivate = true,
+          repoType  = RepoType.Library,
+          language  = Some("Scala")
+        )
+
+      val repoDetails = RepositoryDetails.create(repo, Seq("a team"), urlTemplates)
+
+      repoDetails.githubUrl shouldBe githubLink("https://github.com/org/a-library")
+      repoDetails.ci shouldBe List(
+        Link("Build", "Build", "https://build.tax.service.gov.uk/job/a%20team/job/a-library"))
+    }
+
+    "create links for services" in {
+      val repo =
+        GitRepository(
+          "a-service",
+          "Some Description",
+          "https://github.com/org/a-service",
           now,
           now,
           isPrivate = true,
@@ -118,10 +146,88 @@ class GitRepositorySpec extends WordSpec with Matchers with OptionValues {
           language  = Some("Scala")
         )
 
-      val repoDetails = RepositoryDetails.create(repo, Seq("teamName"), urlTemplates)
+      val repoDetails = RepositoryDetails.create(repo, Seq("a-team"), urlTemplates)
 
-      repoDetails.githubUrl shouldBe githubLink("https://github.com/org/a-frontend")
-      repoDetails.ci        shouldBe List(Link("closed1", "closed 1", "http://closed/a-frontend"))
+      repoDetails.githubUrl shouldBe githubLink("https://github.com/org/a-service")
+      repoDetails.ci        shouldBe List(Link("Build", "Build", "https://build.tax.service.gov.uk/job/a-team/job/a-service"))
+    }
+
+    "create ci links for services belonging to multiple teams" in {
+      val repo =
+        GitRepository(
+          "a-service",
+          "Some Description",
+          "https://github.com/org/a-service",
+          now,
+          now,
+          isPrivate = true,
+          repoType  = RepoType.Service,
+          language  = Some("Scala")
+        )
+
+      val repoDetails = RepositoryDetails.create(repo, Seq("a-team", "another-team"), urlTemplates)
+
+      repoDetails.githubUrl shouldBe githubLink("https://github.com/org/a-service")
+      repoDetails.ci shouldBe List(
+        Link("a-team Build", "a-team Build", "https://build.tax.service.gov.uk/job/a-team/job/a-service"),
+        Link(
+          "another-team Build",
+          "another-team Build",
+          "https://build.tax.service.gov.uk/job/another-team/job/a-service")
+      )
+    }
+
+    "not create ci links for services belonging to no teams" in {
+      val repo =
+        GitRepository(
+          "a-service",
+          "Some Description",
+          "https://github.com/org/a-service",
+          now,
+          now,
+          isPrivate = true,
+          repoType  = RepoType.Service,
+          language  = Some("Scala")
+        )
+
+      val repoDetails = RepositoryDetails.create(repo, Seq(), urlTemplates)
+
+      repoDetails.githubUrl shouldBe githubLink("https://github.com/org/a-service")
+      repoDetails.ci        shouldBe List()
+    }
+
+    "not create ci links for prototype repositories" in {
+      val aLibrary =
+        GitRepository(
+          "a-prototype",
+          "Some Description",
+          "https://not-open-github/org/a-library",
+          now,
+          now,
+          repoType = RepoType.Prototype,
+          language = Some("Scala")
+        )
+
+      val repoDetails = RepositoryDetails.create(aLibrary, Seq("teamName"), urlTemplates)
+
+      repoDetails.ci shouldBe Seq.empty
+    }
+
+    "not create ci links for other type of repositories" in {
+      val aLibrary =
+        GitRepository(
+          "a-other",
+          "Some Description",
+          "https://not-open-github/org/a-library",
+          now,
+          now,
+          repoType = RepoType.Other,
+          language = Some("Scala")
+        )
+
+      val repoDetails = RepositoryDetails.create(aLibrary, Seq("teamName"), urlTemplates)
+
+      repoDetails.ci shouldBe Seq.empty
     }
 
     "create links for each environment" in {
@@ -148,7 +254,7 @@ class GitRepositorySpec extends WordSpec with Matchers with OptionValues {
         List(Link("log1", "log 1", "a-frontend")))
     }
 
-    "do not create environment links for libraries" in {
+    "not create environment links for libraries" in {
       val aLibrary =
         GitRepository(
           "a-library",
@@ -163,40 +269,6 @@ class GitRepositorySpec extends WordSpec with Matchers with OptionValues {
       val repoDetails = RepositoryDetails.create(aLibrary, Seq("teamName"), urlTemplates)
 
       repoDetails.environments shouldBe Seq.empty
-    }
-
-    "create github and ci links for open services" in {
-      val repo =
-        GitRepository(
-          "a-frontend",
-          "Some Description",
-          "https://github.com/org/a-frontend",
-          now,
-          now,
-          repoType = RepoType.Service,
-          language = Some("Scala")
-        )
-
-      val repoDetails = RepositoryDetails.create(repo, Seq("teamName"), urlTemplates)
-
-      repoDetails.githubUrl shouldBe githubLink("https://github.com/org/a-frontend")
-      repoDetails.ci        shouldBe List(Link("open1", "open 1", "http://open/a-frontend"))
-    }
-
-    "create github and ci links for open libraries" in {
-      val repo = GitRepository(
-        "a-library",
-        "Some Description",
-        "https://github.com/org/a-library",
-        now,
-        now,
-        repoType = RepoType.Library,
-        language = Some("Scala"))
-
-      val repoDetails = RepositoryDetails.create(repo, Seq("teamName"), urlTemplates)
-
-      repoDetails.githubUrl shouldBe githubLink("https://github.com/org/a-library")
-      repoDetails.ci        shouldBe List(Link("open1", "open 1", "http://open/a-library"))
     }
 
     "just create github links if not Deployable or Library" in {

--- a/test/uk/gov/hmrc/teamsandrepositories/TeamRepositoriesSpec.scala
+++ b/test/uk/gov/hmrc/teamsandrepositories/TeamRepositoriesSpec.scala
@@ -292,7 +292,7 @@ class TeamRepositoriesSpec extends WordSpec with Matchers with OptionValues {
           System.currentTimeMillis()
         ))
 
-      TeamRepositories.findRepositoryDetails(teams, "repo1", UrlTemplates(Seq(), Seq(), ListMap())) shouldBe defined
+      TeamRepositories.findRepositoryDetails(teams, "repo1", UrlTemplates(ListMap())) shouldBe defined
     }
     "find a repository where the name has a different case" in {
 
@@ -316,7 +316,7 @@ class TeamRepositoriesSpec extends WordSpec with Matchers with OptionValues {
         ))
 
       val Some(repositoryDetails) =
-        TeamRepositories.findRepositoryDetails(teams, "REPO1", UrlTemplates(Seq(), Seq(), ListMap()))
+        TeamRepositories.findRepositoryDetails(teams, "REPO1", UrlTemplates(ListMap()))
 
       repositoryDetails.name       shouldBe "repo1"
       repositoryDetails.repoType   shouldBe Library
@@ -361,7 +361,7 @@ class TeamRepositoriesSpec extends WordSpec with Matchers with OptionValues {
         )
       )
 
-      val result = TeamRepositories.findRepositoryDetails(teams, "repo1", UrlTemplates(Seq(), Seq(), ListMap()))
+      val result = TeamRepositories.findRepositoryDetails(teams, "repo1", UrlTemplates(ListMap()))
       result shouldBe None
     }
 

--- a/test/uk/gov/hmrc/teamsandrepositories/TeamsRepositoriesControllerSpec.scala
+++ b/test/uk/gov/hmrc/teamsandrepositories/TeamsRepositoriesControllerSpec.scala
@@ -419,9 +419,9 @@ class TeamsRepositoriesControllerSpec
       ciDetails.size mustBe 1
 
       ciDetails(0).as[JsObject].as[Map[String, String]] mustBe Map(
-        "name"        -> "open",
-        "displayName" -> "open",
-        "url"         -> "library-repo")
+        "name"        -> "Build",
+        "displayName" -> "Build",
+        "url"         -> "https://build.tax.service.gov.uk/job/test-team/job/library-repo")
     }
   }
 

--- a/test/uk/gov/hmrc/teamsandrepositories/TeamsRepositoriesControllerSpec.scala
+++ b/test/uk/gov/hmrc/teamsandrepositories/TeamsRepositoriesControllerSpec.scala
@@ -97,8 +97,6 @@ class TeamsRepositoriesControllerSpec
 
     when(mockUrlTemplateProvider.ciUrlTemplates).thenReturn(
       UrlTemplates(
-        Seq(UrlTemplate("closed", "closed", "$name")),
-        Seq(UrlTemplate("open", "open", "$name")),
         ListMap(
           "env1" -> Seq(UrlTemplate("log1", "log 1", "$name"), UrlTemplate("mon1", "mon 1", "$name")),
           "env2" -> Seq(UrlTemplate("log1", "log 1", "$name"))
@@ -818,13 +816,10 @@ class TeamsRepositoriesControllerSpec
   private trait Setup {
     when(mockUrlTemplateProvider.ciUrlTemplates).thenReturn(
       UrlTemplates(
-        Seq(UrlTemplate("closed", "closed", "$name")),
-        Seq(UrlTemplate("open", "open", "$name")),
         ListMap(
           "env1" -> Seq(UrlTemplate("log1", "log 1", "$name"), UrlTemplate("mon1", "mon 1", "$name")),
           "env2" -> Seq(UrlTemplate("log1", "log 1", "$name"))
-        )
-      )
+        ))
     )
 
     val controller = new TeamsRepositoriesController(

--- a/test/uk/gov/hmrc/teamsandrepositories/config/TeamsAndRepositoriesConfigSpec.scala
+++ b/test/uk/gov/hmrc/teamsandrepositories/config/TeamsAndRepositoriesConfigSpec.scala
@@ -16,49 +16,18 @@
 
 package uk.gov.hmrc.teamsandrepositories.config
 
-import com.typesafe.config.ConfigFactory
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import play.api.Configuration
 import play.api.inject.guice.GuiceApplicationBuilder
 
 import scala.collection.immutable.ListMap
 
 class TeamsAndRepositoriesConfigSpec extends WordSpec with Matchers with GuiceOneAppPerSuite with MockitoSugar {
 
-  def templatesConfig: String =
-    """
-        |{url-templates : {
-        |  ci-closed : [
-        |    {
-        |      name: "ci-closed1"
-        |      display-name: "closed 1"
-        |      url: "http://closed1/$name"
-        |    },
-        |    {
-        |      name: "ci-closed2"
-        |      display-name: "closed 2"
-        |      url: "http://closed2/$name"
-        |    }]
-        |  ci-open : [
-        |    {
-        |      name: "ci-open1"
-        |      display-name: "open 1"
-        |      url: "http://open1/$name"
-        |    },
-        |    {
-        |      name: "ci-open2"
-        |      display-name: "open 2"
-        |      url: "http://open2/$name"
-        |    }]
-        |}}
-      """.stripMargin
-
   implicit override lazy val app =
     new GuiceApplicationBuilder()
       .disable(classOf[com.kenshoo.play.metrics.PlayModule])
-      .configure(Configuration(ConfigFactory.parseString(templatesConfig)))
       .configure(
         Map(
           "github.open.api.host" -> "http://bla.bla",
@@ -73,12 +42,6 @@ class TeamsAndRepositoriesConfigSpec extends WordSpec with Matchers with GuiceOn
 
       val conf                    = new UrlTemplatesProvider(app.configuration)
       val templates: UrlTemplates = conf.ciUrlTemplates
-      templates.ciClosed shouldBe Seq(
-        UrlTemplate("ci-closed1", "closed 1", "http://closed1/$name"),
-        UrlTemplate("ci-closed2", "closed 2", "http://closed2/$name"))
-      templates.ciOpen shouldBe Seq(
-        UrlTemplate("ci-open1", "open 1", "http://open1/$name"),
-        UrlTemplate("ci-open2", "open 2", "http://open2/$name"))
       templates.environments.toList should contain theSameElementsInOrderAs ListMap(
         "env1" -> Seq(
           UrlTemplate("ser1", "ser 1", "http://ser1/$name"),


### PR DESCRIPTION
This service retrieves the team name from Github. Builds are structured under `job/$jobTeamName/job/$repo` in Jenkins. The build urls will only work when the github team name and the team name as it appears in Jenkins are the same. The `VAT View and Change` team appear as the `VATVC` team in Github so links won't work for this team for example.

Ci Open and Ci Close have been replaced with `http://build.tax.service.gov.uk`

- We no longer get the `ci url` from the config
- When a service or library belong to one team we want the link to appear as `Build`
- When a service or library belong to more then one team we want the link to appear as `Team Name Build`
- Where the url contains a space this should be url encoded correctly
