### PR TITLE
BDOG-879 Isolate scheduling threads from controller threads

### DIFF
--- a/app/uk/gov/hmrc/teamsandrepositories/DataReloadScheduler.scala
+++ b/app/uk/gov/hmrc/teamsandrepositories/DataReloadScheduler.scala
@@ -43,7 +43,7 @@ class DataReloadScheduler @Inject()(
 
   private val logger = Logger(this.getClass)
 
-  import ExecutionContext.Implicits.global
+  implicit val ec: ExecutionContext = actorSystem.dispatchers.lookup("scheduler-dispatcher")
 
   scheduleWithLock("Teams and Repos Reloader", config.dataReloadScheduler, mongoLocks.dataReloadLock) {
     for {

--- a/app/uk/gov/hmrc/teamsandrepositories/GitRepository.scala
+++ b/app/uk/gov/hmrc/teamsandrepositories/GitRepository.scala
@@ -19,8 +19,6 @@ package uk.gov.hmrc.teamsandrepositories
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 import uk.gov.hmrc.teamsandrepositories.RepoType.RepoType
-import uk.gov.hmrc.teamsandrepositories.config.UrlTemplates
-import uk.gov.hmrc.teamsandrepositories.controller.model.RepositoryDetails
 
 case class GitRepository(
   name: String,

--- a/app/uk/gov/hmrc/teamsandrepositories/GithubRatelimitMetricsScheduler.scala
+++ b/app/uk/gov/hmrc/teamsandrepositories/GithubRatelimitMetricsScheduler.scala
@@ -45,12 +45,11 @@ class GithubRatelimitMetricsScheduler @Inject()(
    )( implicit
       actorSystem         : ActorSystem
     , applicationLifecycle: ApplicationLifecycle
-    , ec                  : ExecutionContext
     ) extends SchedulerUtils {
 
   implicit val hc: HeaderCarrier = HeaderCarrier()
 
-
+  implicit val ec: ExecutionContext = actorSystem.dispatchers.lookup("scheduler-dispatcher")
 
   val metricsDefinitions: Map[String, () => Future[Int]] = {
     githubConfig.tokens.map { case (username, token) =>

--- a/app/uk/gov/hmrc/teamsandrepositories/GithubRatelimitMetricsScheduler.scala
+++ b/app/uk/gov/hmrc/teamsandrepositories/GithubRatelimitMetricsScheduler.scala
@@ -29,7 +29,7 @@ import uk.gov.hmrc.metrix.persistence.MongoMetricRepository
 import uk.gov.hmrc.teamsandrepositories.config.{GithubConfig, SchedulerConfigs}
 import uk.gov.hmrc.teamsandrepositories.helpers.SchedulerUtils
 import uk.gov.hmrc.teamsandrepositories.persitence.MongoLocks
-import uk.gov.hmrc.teamsandrepositories.connectors.{GithubConnector, RateLimitMetrics}
+import uk.gov.hmrc.teamsandrepositories.connectors.GithubConnector
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/app/uk/gov/hmrc/teamsandrepositories/JenkinsScheduler.scala
+++ b/app/uk/gov/hmrc/teamsandrepositories/JenkinsScheduler.scala
@@ -29,18 +29,20 @@ import uk.gov.hmrc.teamsandrepositories.services.JenkinsService
 import scala.concurrent.ExecutionContext
 
 @Singleton
-class JenkinsScheduler @Inject()(jenkinsService: JenkinsService,
-                                 config: SchedulerConfigs,
-                                 mongoLocks: MongoLocks)(
-                                 implicit actorSystem: ActorSystem,
-                                 applicationLifecycle: ApplicationLifecycle)
-extends SchedulerUtils {
+class JenkinsScheduler @Inject()(
+  jenkinsService: JenkinsService,
+  config        : SchedulerConfigs,
+  mongoLocks    : MongoLocks
+)(implicit
+  actorSystem         : ActorSystem,
+  applicationLifecycle: ApplicationLifecycle
+) extends SchedulerUtils {
 
   implicit val hc: HeaderCarrier = HeaderCarrier()
 
   private val logger = Logger(this.getClass)
 
-  import ExecutionContext.Implicits.global
+  implicit val ec: ExecutionContext = actorSystem.dispatchers.lookup("scheduler-dispatcher")
 
   scheduleWithLock("Jenkins Reloader", config.jenkinsScheduler, mongoLocks.jenkinsLock) {
     for {
@@ -48,5 +50,4 @@ extends SchedulerUtils {
       _ =  logger.info("Finished updating Build Jobs")
     } yield ()
   }
-
 }

--- a/app/uk/gov/hmrc/teamsandrepositories/config/JenkinsConfig.scala
+++ b/app/uk/gov/hmrc/teamsandrepositories/config/JenkinsConfig.scala
@@ -19,8 +19,6 @@ package uk.gov.hmrc.teamsandrepositories.config
 import javax.inject.Inject
 import play.api.Configuration
 
-import scala.language.postfixOps
-
 class JenkinsConfig @Inject()(config: Configuration) {
   lazy val username: String = config.get[String]("jenkins.username")
 

--- a/app/uk/gov/hmrc/teamsandrepositories/connectors/GithubConnector.scala
+++ b/app/uk/gov/hmrc/teamsandrepositories/connectors/GithubConnector.scala
@@ -20,7 +20,6 @@ import javax.inject.Inject
 import play.api.libs.functional.syntax._
 import play.api.libs.json.{Reads, __}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
-import uk.gov.hmrc.githubclient.GitApiConfig
 import uk.gov.hmrc.http.logging.Authorization
 import uk.gov.hmrc.play.bootstrap.http.HttpClient
 import uk.gov.hmrc.teamsandrepositories.config.GithubConfig

--- a/app/uk/gov/hmrc/teamsandrepositories/controller/JenkinsController.scala
+++ b/app/uk/gov/hmrc/teamsandrepositories/controller/JenkinsController.scala
@@ -34,7 +34,7 @@ class JenkinsController @Inject()(
 
   private implicit val apiWriter: Writes[BuildJob] = BuildJob.apiWriter
 
-  def lookup(service: String): Action[AnyContent] = Action.async { implicit request =>
+  def lookup(service: String): Action[AnyContent] = Action.async {
     for {
       findService <- jenkinsService.findByService(service)
       result      =  findService.map(links => Ok(Json.toJson(links))).getOrElse(NoContent)

--- a/app/uk/gov/hmrc/teamsandrepositories/controller/JenkinsController.scala
+++ b/app/uk/gov/hmrc/teamsandrepositories/controller/JenkinsController.scala
@@ -23,11 +23,14 @@ import uk.gov.hmrc.play.bootstrap.controller.BackendController
 import uk.gov.hmrc.teamsandrepositories.persitence.model.BuildJob
 import uk.gov.hmrc.teamsandrepositories.services.JenkinsService
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext
 
 @Singleton
-class JenkinsController @Inject()(jenkinsService: JenkinsService, cc: ControllerComponents)
-  extends BackendController(cc) {
+class JenkinsController @Inject()(
+  jenkinsService: JenkinsService,
+  cc            : ControllerComponents
+)(implicit ec: ExecutionContext
+) extends BackendController(cc) {
 
   private implicit val apiWriter: Writes[BuildJob] = BuildJob.apiWriter
 
@@ -36,6 +39,5 @@ class JenkinsController @Inject()(jenkinsService: JenkinsService, cc: Controller
       findService <- jenkinsService.findByService(service)
       result      =  findService.map(links => Ok(Json.toJson(links))).getOrElse(NoContent)
     } yield result
-
   }
 }

--- a/app/uk/gov/hmrc/teamsandrepositories/controller/TeamsRepositoriesController.scala
+++ b/app/uk/gov/hmrc/teamsandrepositories/controller/TeamsRepositoriesController.scala
@@ -17,7 +17,6 @@
 package uk.gov.hmrc.teamsandrepositories.controller
 
 import java.net.URLDecoder
-import java.util.concurrent.Executors
 
 import com.google.inject.{Inject, Singleton}
 import play.api.Configuration
@@ -32,12 +31,7 @@ import uk.gov.hmrc.teamsandrepositories.persitence.model.TeamRepositories
 import uk.gov.hmrc.teamsandrepositories.persitence.model.TeamRepositories.DigitalService
 import uk.gov.hmrc.teamsandrepositories.{DataReloadScheduler, RepoType}
 
-import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
-import scala.concurrent.ExecutionContext.Implicits.global
-
-object BlockingIOExecutionContext {
-  implicit val executionContext: ExecutionContextExecutor = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(20))
-}
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class TeamsRepositoriesController @Inject()(
@@ -46,8 +40,9 @@ class TeamsRepositoriesController @Inject()(
   urlTemplatesProvider: UrlTemplatesProvider,
   configuration: Configuration,
   mongoTeamsAndReposPersister: TeamsAndReposPersister,
-  controllerComponents: ControllerComponents)
-    extends BackendController(controllerComponents) {
+  controllerComponents: ControllerComponents
+)(implicit ec: ExecutionContext
+) extends BackendController(controllerComponents) {
 
 
   val TimestampHeaderName = "X-Cache-Timestamp"

--- a/app/uk/gov/hmrc/teamsandrepositories/controller/TeamsRepositoriesController.scala
+++ b/app/uk/gov/hmrc/teamsandrepositories/controller/TeamsRepositoriesController.scala
@@ -103,7 +103,7 @@ class TeamsRepositoriesController @Inject()(
     }
   }
 
-  def digitalServices() = Action.async { implicit request =>
+  def digitalServices() = Action.async {
     mongoTeamsAndReposPersister.getAllTeamsAndRepos.map { allTeamsAndRepos =>
       val digitalServices: Seq[String] =
         allTeamsAndRepos
@@ -126,7 +126,7 @@ class TeamsRepositoriesController @Inject()(
     }
   }
 
-  def teams() = Action.async { implicit request =>
+  def teams() = Action.async {
     mongoTeamsAndReposPersister.getAllTeamsAndRepos.map { allTeamsAndRepos =>
       Ok(toJson(TeamRepositories.getTeamList(allTeamsAndRepos, repositoriesToIgnore)))
     }

--- a/app/uk/gov/hmrc/teamsandrepositories/helpers/FutureExtras.scala
+++ b/app/uk/gov/hmrc/teamsandrepositories/helpers/FutureExtras.scala
@@ -16,22 +16,22 @@
 
 package uk.gov.hmrc.teamsandrepositories.helpers
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 object FutureExtras {
 
   implicit class FutureOfBoolean(f: Future[Boolean]) {
 
-    def ||(f1: => Future[Boolean]): Future[Boolean] = f.flatMap { bv =>
-      if (bv) Future.successful(bv)
-      else f1
-    }
+    def ||(f1: => Future[Boolean])(implicit ec: ExecutionContext): Future[Boolean] =
+      f.flatMap {
+        case true => Future.successful(true)
+        case _    => f1
+      }
 
-    def &&(f1: => Future[Boolean]): Future[Boolean] = f.flatMap { bv =>
-      if (!bv) Future.successful(bv)
-      else f1
-    }
+    def &&(f1: => Future[Boolean])(implicit ec: ExecutionContext): Future[Boolean] =
+      f.flatMap {
+        case false => Future.successful(false)
+        case _     => f1
+      }
   }
-
 }

--- a/app/uk/gov/hmrc/teamsandrepositories/helpers/FutureHelpers.scala
+++ b/app/uk/gov/hmrc/teamsandrepositories/helpers/FutureHelpers.scala
@@ -19,7 +19,6 @@ package uk.gov.hmrc.teamsandrepositories.helpers
 import com.codahale.metrics.MetricRegistry
 import com.kenshoo.play.metrics.Metrics
 import javax.inject.{Inject, Singleton}
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
@@ -28,7 +27,7 @@ class FutureHelpers @Inject()(metrics: Metrics) {
 
   val defaultMetricsRegistry: MetricRegistry = metrics.defaultRegistry
 
-  def withTimerAndCounter[T](name: String)(f: Future[T]) = {
+  def withTimerAndCounter[T](name: String)(f: Future[T])(implicit ec: ExecutionContext) = {
     val t = defaultMetricsRegistry.timer(s"$name.timer").time()
     f.andThen {
       case Success(_) =>

--- a/app/uk/gov/hmrc/teamsandrepositories/helpers/RetryStrategy.scala
+++ b/app/uk/gov/hmrc/teamsandrepositories/helpers/RetryStrategy.scala
@@ -18,7 +18,6 @@ package uk.gov.hmrc.teamsandrepositories.helpers
 
 import java.util.{Timer, TimerTask}
 
-import org.slf4j.LoggerFactory
 import play.api.Logger
 import uk.gov.hmrc.githubclient.APIRateLimitExceededException
 

--- a/app/uk/gov/hmrc/teamsandrepositories/persitence/BuildJobRepo.scala
+++ b/app/uk/gov/hmrc/teamsandrepositories/persitence/BuildJobRepo.scala
@@ -24,12 +24,9 @@ import reactivemongo.bson.BSONObjectID
 import uk.gov.hmrc.mongo.ReactiveRepository
 import uk.gov.hmrc.teamsandrepositories.persitence.model.BuildJob
 import play.api.libs.json.Json.toJsFieldJsValueWrapper
-
-import scala.concurrent.ExecutionContext.Implicits.global
 import reactivemongo.play.json.ImplicitBSONHandlers._
 
-
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class BuildJobRepo @Inject()(mongoConnector: MongoConnector)
@@ -41,12 +38,11 @@ class BuildJobRepo @Inject()(mongoConnector: MongoConnector)
   override def indexes: Seq[Index] =
     Seq(Index(Seq("service" -> IndexType.Hashed), name = Some("serviceIdx")))
 
+  def findByService(service: String)(implicit ec: ExecutionContext): Future[Option[BuildJob]] =
+    find("service" -> service)
+      .map(_.headOption)
 
-  def findByService(service: String): Future[Option[BuildJob]] = {
-    find("service" -> service).map(_.headOption)
-  }
-
-  def updateOne(buildJob: BuildJob): Future[UpdateWriteResult] = {
+  def updateOne(buildJob: BuildJob)(implicit ec: ExecutionContext): Future[UpdateWriteResult] = {
     collection
       .update(ordered=false)
       .one(
@@ -56,7 +52,6 @@ class BuildJobRepo @Inject()(mongoConnector: MongoConnector)
       )
   }
 
-  def update(buildJobs: Seq[BuildJob]): Future[Seq[UpdateWriteResult]] =
+  def update(buildJobs: Seq[BuildJob])(implicit ec: ExecutionContext): Future[Seq[UpdateWriteResult]] =
     Future.traverse(buildJobs)(updateOne)
-
 }

--- a/app/uk/gov/hmrc/teamsandrepositories/services/JenkinsService.scala
+++ b/app/uk/gov/hmrc/teamsandrepositories/services/JenkinsService.scala
@@ -22,18 +22,17 @@ import uk.gov.hmrc.teamsandrepositories.connectors.JenkinsConnector
 import uk.gov.hmrc.teamsandrepositories.persitence.BuildJobRepo
 import uk.gov.hmrc.teamsandrepositories.persitence.model.BuildJob
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 
 @Singleton
 class JenkinsService @Inject()(repo: BuildJobRepo, jenkinsConnector: JenkinsConnector){
 
-  def findByService(service: String): Future[Option[BuildJob]] = {
+  def findByService(service: String)(implicit ec: ExecutionContext): Future[Option[BuildJob]] = {
     repo.findByService(service)
   }
 
-  def updateBuildJobs(): Future[Seq[UpdateWriteResult]] = {
+  def updateBuildJobs()(implicit ec: ExecutionContext): Future[Seq[UpdateWriteResult]] = {
     for {
       res <- jenkinsConnector.findBuildJobRoot()
       buildJobs = res.map(build => BuildJob(build.displayName, build.url))

--- a/app/uk/gov/hmrc/teamsandrepositories/testonly/IntegrationTestSupportController.scala
+++ b/app/uk/gov/hmrc/teamsandrepositories/testonly/IntegrationTestSupportController.scala
@@ -24,13 +24,15 @@ import uk.gov.hmrc.teamsandrepositories.helpers.FutureHelpers
 import uk.gov.hmrc.teamsandrepositories.persitence.{BuildJobRepo, TeamsAndReposPersister}
 import uk.gov.hmrc.teamsandrepositories.persitence.model.{BuildJob, TeamRepositories}
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
-class IntegrationTestSupportController @Inject()(teamsRepo: TeamsAndReposPersister,
-                                                 jenkinsRepo: BuildJobRepo,
-                                                 futureHelpers: FutureHelpers,
-                                                 cc: ControllerComponents) extends BackendController(cc) {
+class IntegrationTestSupportController @Inject()(
+  teamsRepo    : TeamsAndReposPersister,
+  jenkinsRepo  : BuildJobRepo,
+  futureHelpers: FutureHelpers,
+  cc           : ControllerComponents
+)(implicit ec: ExecutionContext
+) extends BackendController(cc) {
 
   private implicit val mongoFormats: Reads[BuildJob] = BuildJob.mongoFormats
 

--- a/app/uk/gov/hmrc/teamsandrepositories/testonly/IntegrationTestSupportController.scala
+++ b/app/uk/gov/hmrc/teamsandrepositories/testonly/IntegrationTestSupportController.scala
@@ -43,7 +43,7 @@ class IntegrationTestSupportController @Inject()(
     Future.sequence(request.body.map(teamsRepo.update)).map(_ => Ok("Done"))
   }
 
-  def clearAll() = Action.async { implicit request =>
+  def clearAll() = Action.async {
      teamsRepo.clearAllData.map(_ => Ok("Ok"))
   }
 
@@ -51,7 +51,7 @@ class IntegrationTestSupportController @Inject()(
     jenkinsRepo.update(request.body).map(_ => Ok("Done"))
   }
 
-  def clearJenkins() = Action.async { implicit request =>
+  def clearJenkins() = Action.async {
     jenkinsRepo.removeAll().map(_ => Ok("Ok"))
   }
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -170,3 +170,15 @@ github.open.api.rawurl = "http://localhost:8461/github/raw"
 
 ratemetrics.githubtokens.1.username = ${?github.open.api.user}
 ratemetrics.githubtokens.1.token    = ${?github.open.api.key}
+
+
+# for scheduling execution context, to not interfer with Controllers, which should always be responsive.
+# The Controllers use the injectected execution context, which uses a fork-join-executor.
+# Here we are using a limited thread-pool-excutor to ensure we don't steal resources
+scheduler-dispatcher {
+  type = Dispatcher
+  executor = "uk.gov.hmrc.play.bootstrap.dispatchers.MDCPropagatingExecutorServiceConfigurator"
+  thread-pool-executor {
+    fixed-pool-size = 32
+  }
+}

--- a/test/uk/gov/hmrc/teamsandrepositories/DataReloadSchedulerSpec.scala
+++ b/test/uk/gov/hmrc/teamsandrepositories/DataReloadSchedulerSpec.scala
@@ -34,10 +34,9 @@ import uk.gov.hmrc.teamsandrepositories.config.SchedulerConfigs
 import uk.gov.hmrc.teamsandrepositories.persitence.{LockKeeper, MongoLocks}
 import uk.gov.hmrc.teamsandrepositories.services.PersistingService
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration._
+import scala.concurrent.duration.DurationInt
 import scala.concurrent.{ExecutionContext, Future}
-import scala.language.postfixOps
+import scala.concurrent.ExecutionContext.Implicits.global
 
 class DataReloadSchedulerSpec
     extends AnyWordSpec
@@ -73,8 +72,8 @@ class DataReloadSchedulerSpec
     when(mockPersistingService.persistTeamRepoMapping(any())).thenReturn(Future(Nil))
     when(mockPersistingService.removeOrphanTeamsFromMongo(any())(any())).thenReturn(Future(Set.empty[String]))
 
-    when(mockSchedulerConfigs.dataReloadScheduler.initialDelay).thenReturn(100 millisecond)
-    when(mockSchedulerConfigs.dataReloadScheduler.interval).thenReturn(100 millisecond)
+    when(mockSchedulerConfigs.dataReloadScheduler.initialDelay).thenReturn(100.millisecond)
+    when(mockSchedulerConfigs.dataReloadScheduler.interval).thenReturn(100.millisecond)
     when(mockSchedulerConfigs.dataReloadScheduler.enabled).thenReturn(true)
 
     new DataReloadScheduler(
@@ -97,8 +96,8 @@ class DataReloadSchedulerSpec
       when(mockPersistingService.persistTeamRepoMapping(any())).thenReturn(Future(Nil))
       when(mockPersistingService.removeOrphanTeamsFromMongo(any())(any())).thenReturn(Future(Set.empty[String]))
 
-      when(mockSchedulerConfigs.dataReloadScheduler.initialDelay).thenReturn(100 millisecond)
-      when(mockSchedulerConfigs.dataReloadScheduler.interval).thenReturn(100 millisecond)
+      when(mockSchedulerConfigs.dataReloadScheduler.initialDelay).thenReturn(100.millisecond)
+      when(mockSchedulerConfigs.dataReloadScheduler.interval).thenReturn(100.millisecond)
       when(mockSchedulerConfigs.dataReloadScheduler.enabled).thenReturn(false)
 
       new DataReloadScheduler(

--- a/test/uk/gov/hmrc/teamsandrepositories/GithubV3RepositoryDataSourceSpec.scala
+++ b/test/uk/gov/hmrc/teamsandrepositories/GithubV3RepositoryDataSourceSpec.scala
@@ -836,8 +836,7 @@ class GithubV3RepositoryDataSourceSpec
           when(mockGithubClient.getTeamsForOrganisation("hmrc")(ec))
             .thenReturn(Future.successful(List(team)))
 
-          val lastActiveDate: Long                  = 1234L
-          val previousLastSuccessfulScheduledUpdate = Option.empty[Long]
+          val lastActiveDate: Long = 1234L
 
           when(mockGithubClient.getReposForTeam(1)(ec))
             .thenReturn(Future.successful(

--- a/test/uk/gov/hmrc/teamsandrepositories/GithubV3RepositoryDataSourceSpec.scala
+++ b/test/uk/gov/hmrc/teamsandrepositories/GithubV3RepositoryDataSourceSpec.scala
@@ -21,8 +21,7 @@ import java.util.Date
 import com.codahale.metrics.{Counter, MetricRegistry}
 import com.kenshoo.play.metrics.Metrics
 import org.mockito.Mockito._
-import org.mockito.ArgumentMatchers.{any, anyString}
-
+import org.mockito.ArgumentMatchers.{any, anyString, eq => eqTo}
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.concurrent.ScalaFutures
@@ -30,18 +29,15 @@ import org.scalatest.time.SpanSugar
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
-
 import uk.gov.hmrc.githubclient._
 import uk.gov.hmrc.teamsandrepositories.config.GithubConfig
 import uk.gov.hmrc.teamsandrepositories.connectors.GithubConnector
-import uk.gov.hmrc.teamsandrepositories.controller.BlockingIOExecutionContext
 import uk.gov.hmrc.teamsandrepositories.helpers.FutureHelpers
 import uk.gov.hmrc.teamsandrepositories.persitence.model.TeamRepositories
 import uk.gov.hmrc.teamsandrepositories.persitence.{MongoTeamsAndRepositoriesPersister, TeamsAndReposPersister}
 import uk.gov.hmrc.teamsandrepositories.services.GithubV3RepositoryDataSource
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.language.postfixOps
 
 class GithubV3RepositoryDataSourceSpec
     extends AnyWordSpec
@@ -80,6 +76,7 @@ class GithubV3RepositoryDataSourceSpec
         futureHelpers          = new FutureHelpers(metrics)
       )
 
+    val ec = dataSource.ec
 
     when(mockGithubClient.repoContainsContent(anyString(), anyString(), anyString())(any[ExecutionContext]))
       .thenReturn(Future.successful(false))
@@ -99,8 +96,6 @@ class GithubV3RepositoryDataSourceSpec
 
   val githubConfig: GithubConfig = mock[GithubConfig]
 
-  val ec = BlockingIOExecutionContext.executionContext
-
   private val metrics: Metrics = new Metrics() {
     override def defaultRegistry = new MetricRegistry
     override def toJson          = ???
@@ -110,9 +105,9 @@ class GithubV3RepositoryDataSourceSpec
       extends TeamsAndReposPersister(mock[MongoTeamsAndRepositoriesPersister], new FutureHelpers(metrics)) {
     var captor: List[TeamRepositories] = Nil
 
-    override def update(teamsAndRepositories: TeamRepositories): Future[TeamRepositories] = {
+    override def update(teamsAndRepositories: TeamRepositories)(implicit ec: ExecutionContext): Future[TeamRepositories] = {
       captor +:= teamsAndRepositories
-      Future(teamsAndRepositories)(ec)
+      Future.successful(teamsAndRepositories)
     }
   }
 
@@ -130,7 +125,6 @@ class GithubV3RepositoryDataSourceSpec
       result.size shouldBe 2
       result      should contain theSameElementsAs Seq(teamA, teamB)
     }
-
   }
 
   "Github v3 Data Source getAllRepositories" should {
@@ -166,9 +160,9 @@ class GithubV3RepositoryDataSourceSpec
         )
 
       private val team = GhTeam("A", 1)
-      when(mockGithubClient.getTeamsForOrganisation("hmrc")(ec))
+      when(mockGithubClient.getTeamsForOrganisation(eqTo("hmrc"))(any()))
         .thenReturn(Future.successful(List(team)))
-      when(mockGithubClient.getReposForTeam(1)(ec))
+      when(mockGithubClient.getReposForTeam(1)(internalDataSource.ec))
         .thenReturn(Future.successful(List(GhRepository("A_r", "some description", 1, "url_A", fork = false, now, now, false, "Scala"))))
 
       internalDataSource

--- a/test/uk/gov/hmrc/teamsandrepositories/ModuleSpec.scala
+++ b/test/uk/gov/hmrc/teamsandrepositories/ModuleSpec.scala
@@ -25,7 +25,6 @@ import org.scalatest.concurrent.Eventually
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.Application
 import play.api.inject.bind
@@ -38,7 +37,6 @@ import uk.gov.hmrc.teamsandrepositories.services.{PersistingService, Timestamper
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
-import scala.language.postfixOps
 
 class ModuleSpec
   extends AnyWordSpec

--- a/test/uk/gov/hmrc/teamsandrepositories/MongoTeamsAndRepositoriesPersisterSpec.scala
+++ b/test/uk/gov/hmrc/teamsandrepositories/MongoTeamsAndRepositoriesPersisterSpec.scala
@@ -27,6 +27,7 @@ import uk.gov.hmrc.mongo.MongoSpecSupport
 import uk.gov.hmrc.teamsandrepositories.persitence.MongoTeamsAndRepositoriesPersister
 import uk.gov.hmrc.teamsandrepositories.persitence.model.TeamRepositories
 
+import scala.concurrent.duration.DurationInt
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class MongoTeamsAndRepositoriesPersisterSpec
@@ -38,6 +39,8 @@ class MongoTeamsAndRepositoriesPersisterSpec
     with OptionValues
     with BeforeAndAfterEach
     with GuiceOneAppPerSuite {
+
+  override implicit val patienceConfig = PatienceConfig(timeout = 30.seconds, interval = 100.millis)
 
   implicit override lazy val app: Application =
     new GuiceApplicationBuilder()

--- a/test/uk/gov/hmrc/teamsandrepositories/MongoTeamsAndRepositoriesPersisterSpec.scala
+++ b/test/uk/gov/hmrc/teamsandrepositories/MongoTeamsAndRepositoriesPersisterSpec.scala
@@ -28,7 +28,6 @@ import uk.gov.hmrc.teamsandrepositories.persitence.MongoTeamsAndRepositoriesPers
 import uk.gov.hmrc.teamsandrepositories.persitence.model.TeamRepositories
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
 
 class MongoTeamsAndRepositoriesPersisterSpec
     extends AnyWordSpec
@@ -51,10 +50,6 @@ class MongoTeamsAndRepositoriesPersisterSpec
 
   val mongoTeamsAndReposPersister = app.injector.instanceOf(classOf[MongoTeamsAndRepositoriesPersister])
 
-  def await[T](f: Future[T]) : T = {
-    f.futureValue
-  }
-
   override def beforeEach() {
     mongoTeamsAndReposPersister.drop.futureValue
   }
@@ -75,10 +70,10 @@ class MongoTeamsAndRepositoriesPersisterSpec
         TeamRepositories("test-team1", List(gitRepository1, gitRepository2), System.currentTimeMillis())
       val teamAndRepositories2 =
         TeamRepositories("test-team2", List(gitRepository3, gitRepository4), System.currentTimeMillis())
-      await(mongoTeamsAndReposPersister.insert(teamAndRepositories1))
-      await(mongoTeamsAndReposPersister.insert(teamAndRepositories2))
+      mongoTeamsAndReposPersister.insert(teamAndRepositories1).futureValue
+      mongoTeamsAndReposPersister.insert(teamAndRepositories2).futureValue
 
-      val all = await(mongoTeamsAndReposPersister.getAllTeamAndRepos)
+      val all = mongoTeamsAndReposPersister.getAllTeamAndRepos.futureValue
 
       all should contain theSameElementsAs Seq(teamAndRepositories1, teamAndRepositories2)
     }
@@ -92,21 +87,21 @@ class MongoTeamsAndRepositoriesPersisterSpec
         GitRepository("repo-name2", "Desc2", "url2", 3, 4, false, RepoType.Library, language = Some("Scala"))
       val teamAndRepositories1 =
         TeamRepositories("test-team1", List(gitRepository1, gitRepository2), System.currentTimeMillis())
-      await(mongoTeamsAndReposPersister.insert(teamAndRepositories1))
+      mongoTeamsAndReposPersister.insert(teamAndRepositories1).futureValue
 
       val gitRepository3 =
         GitRepository("repo-name3", "Desc3", "url3", 1, 2, false, RepoType.Service, language = Some("Scala"))
       val teamAndRepositories2 =
         TeamRepositories("test-team2", List(gitRepository3), System.currentTimeMillis())
-      await(mongoTeamsAndReposPersister.insert(teamAndRepositories2))
+      mongoTeamsAndReposPersister.insert(teamAndRepositories2).futureValue
 
       val gitRepository4 =
         GitRepository("repo-name4", "Desc4", "url4", 3, 4, false, RepoType.Library, language = Some("Scala"))
       val teamAndRepositories3 =
         TeamRepositories("test-team2", List(gitRepository4), System.currentTimeMillis())
-      await(mongoTeamsAndReposPersister.insert(teamAndRepositories3))
+      mongoTeamsAndReposPersister.insert(teamAndRepositories3).futureValue
 
-      val result = await(mongoTeamsAndReposPersister.getTeamsAndRepos(Seq("repo-name1", "repo-name4")))
+      val result = mongoTeamsAndReposPersister.getTeamsAndRepos(Seq("repo-name1", "repo-name4")).futureValue
 
       result should contain theSameElementsAs List(teamAndRepositories1, teamAndRepositories3)
     }
@@ -120,19 +115,18 @@ class MongoTeamsAndRepositoriesPersisterSpec
         GitRepository("repo-name2", "Desc2", "url2", 3, 4, false, RepoType.Library, language = Some("Scala"))
 
       val teamAndRepositories1 = TeamRepositories("test-team", List(gitRepository1), System.currentTimeMillis())
-      await(mongoTeamsAndReposPersister.insert(teamAndRepositories1))
+      mongoTeamsAndReposPersister.insert(teamAndRepositories1).futureValue
 
       val teamAndRepositories2 = TeamRepositories("test-team", List(gitRepository2), System.currentTimeMillis())
-      await(mongoTeamsAndReposPersister.update(teamAndRepositories2))
+      mongoTeamsAndReposPersister.update(teamAndRepositories2).futureValue
 
-      val allUpdated = await(mongoTeamsAndReposPersister.getAllTeamAndRepos)
+      val allUpdated = mongoTeamsAndReposPersister.getAllTeamAndRepos.futureValue
       allUpdated.size shouldBe 1
       val updatedDeployment: TeamRepositories = allUpdated.loneElement
 
       updatedDeployment.teamName     shouldBe "test-team"
       updatedDeployment.repositories shouldBe List(gitRepository2)
     }
-
   }
 
   "deleteTeam" should {
@@ -153,15 +147,15 @@ class MongoTeamsAndRepositoriesPersisterSpec
         TeamRepositories("test-team2", List(gitRepository3, gitRepository4), System.currentTimeMillis())
       val teamAndRepositories3 = TeamRepositories("test-team3", List(gitRepository1), System.currentTimeMillis())
 
-      await(mongoTeamsAndReposPersister.insert(teamAndRepositories1))
-      await(mongoTeamsAndReposPersister.insert(teamAndRepositories2))
-      await(mongoTeamsAndReposPersister.insert(teamAndRepositories3))
+      mongoTeamsAndReposPersister.insert(teamAndRepositories1).futureValue
+      mongoTeamsAndReposPersister.insert(teamAndRepositories2).futureValue
+      mongoTeamsAndReposPersister.insert(teamAndRepositories3).futureValue
 
       List("test-team1", "test-team2").foreach { teamName =>
-        await(mongoTeamsAndReposPersister.deleteTeam(teamName))
+        mongoTeamsAndReposPersister.deleteTeam(teamName).futureValue
       }
 
-      val allRemainingTeams = await(mongoTeamsAndReposPersister.getAllTeamAndRepos)
+      val allRemainingTeams = mongoTeamsAndReposPersister.getAllTeamAndRepos.futureValue
       allRemainingTeams.size shouldBe 1
 
       allRemainingTeams shouldBe List(teamAndRepositories3)
@@ -181,11 +175,11 @@ class MongoTeamsAndRepositoriesPersisterSpec
       val teamAndRepositories1 =
         TeamRepositories("test-team1", List(gitRepository1, gitRepository2, gitRepository3), System.currentTimeMillis())
 
-      await(mongoTeamsAndReposPersister.insert(teamAndRepositories1))
+      mongoTeamsAndReposPersister.insert(teamAndRepositories1).futureValue
 
-      await(mongoTeamsAndReposPersister.resetLastActiveDate(gitRepository2.name)) shouldBe Some(1)
+      mongoTeamsAndReposPersister.resetLastActiveDate(gitRepository2.name).futureValue shouldBe Some(1)
 
-      val persistedTeam = await(mongoTeamsAndReposPersister.getAllTeamAndRepos).head
+      val persistedTeam = mongoTeamsAndReposPersister.getAllTeamAndRepos.futureValue.head
 
       persistedTeam.repositories should contain theSameElementsAs Seq(
         gitRepository1,
@@ -199,17 +193,17 @@ class MongoTeamsAndRepositoriesPersisterSpec
         GitRepository("repo-name1", "Desc1", "url1", 1, 2, false, RepoType.Service, language = Some("Scala"))
       val teamAndRepositories1 =
         TeamRepositories("test-team1", List(gitRepository1), System.currentTimeMillis())
-      await(mongoTeamsAndReposPersister.insert(teamAndRepositories1))
+      mongoTeamsAndReposPersister.insert(teamAndRepositories1).futureValue
 
       val gitRepository2 =
         GitRepository("repo-name1", "Desc2", "url2", 1, 2, false, RepoType.Service, language = Some("Scala"))
       val teamAndRepositories2 =
         TeamRepositories("test-team2", List(gitRepository2), System.currentTimeMillis())
-      await(mongoTeamsAndReposPersister.insert(teamAndRepositories2))
+      mongoTeamsAndReposPersister.insert(teamAndRepositories2).futureValue
 
-      await(mongoTeamsAndReposPersister.resetLastActiveDate(gitRepository1.name)) shouldBe Some(2)
+      mongoTeamsAndReposPersister.resetLastActiveDate(gitRepository1.name).futureValue shouldBe Some(2)
 
-      await(mongoTeamsAndReposPersister.getAllTeamAndRepos) should contain theSameElementsAs Seq(
+      mongoTeamsAndReposPersister.getAllTeamAndRepos.futureValue should contain theSameElementsAs Seq(
         teamAndRepositories1.copy(repositories = List(gitRepository1.copy(lastActiveDate = 0L))),
         teamAndRepositories2.copy(repositories = List(gitRepository2.copy(lastActiveDate = 0L)))
       )
@@ -222,11 +216,11 @@ class MongoTeamsAndRepositoriesPersisterSpec
       val teamAndRepositories1 =
         TeamRepositories("test-team1", List(gitRepository1), System.currentTimeMillis())
 
-      await(mongoTeamsAndReposPersister.insert(teamAndRepositories1))
+      mongoTeamsAndReposPersister.insert(teamAndRepositories1).futureValue
 
-      await(mongoTeamsAndReposPersister.resetLastActiveDate("non-exisiting-repo")) shouldBe None
+      mongoTeamsAndReposPersister.resetLastActiveDate("non-exisiting-repo").futureValue shouldBe None
 
-      await(mongoTeamsAndReposPersister.getAllTeamAndRepos) shouldBe Seq(teamAndRepositories1)
+      mongoTeamsAndReposPersister.getAllTeamAndRepos.futureValue shouldBe Seq(teamAndRepositories1)
     }
   }
 }

--- a/test/uk/gov/hmrc/teamsandrepositories/TeamsAndReposPersisterSpec.scala
+++ b/test/uk/gov/hmrc/teamsandrepositories/TeamsAndReposPersisterSpec.scala
@@ -33,6 +33,8 @@ import uk.gov.hmrc.teamsandrepositories.persitence.model.TeamRepositories
 import uk.gov.hmrc.teamsandrepositories.persitence.{MongoTeamsAndRepositoriesPersister, TeamsAndReposPersister}
 
 import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+
 
 class TeamsAndReposPersisterSpec
     extends AnyWordSpec

--- a/test/uk/gov/hmrc/teamsandrepositories/TeamsRepositoriesControllerSpec.scala
+++ b/test/uk/gov/hmrc/teamsandrepositories/TeamsRepositoriesControllerSpec.scala
@@ -26,7 +26,6 @@ import org.scalatest.concurrent.Eventually
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.libs.json._
 import play.api.mvc.Results
@@ -41,6 +40,8 @@ import uk.gov.hmrc.teamsandrepositories.persitence.model.TeamRepositories
 
 import scala.collection.immutable.ListMap
 import scala.concurrent.Future
+
+import scala.concurrent.ExecutionContext.Implicits.global
 
 class TeamsRepositoriesControllerSpec
     extends AnyWordSpec

--- a/test/uk/gov/hmrc/teamsandrepositories/connectors/JenkinsConnectorSpec.scala
+++ b/test/uk/gov/hmrc/teamsandrepositories/connectors/JenkinsConnectorSpec.scala
@@ -23,6 +23,8 @@ import play.api.libs.json.{JsSuccess, Json}
 
 import scala.concurrent.Future
 
+import scala.concurrent.ExecutionContext.Implicits.global
+
 class JenkinsConnectorSpec extends AnyWordSpec with Matchers with ScalaFutures {
   import JenkinsApiReads._
 

--- a/test/uk/gov/hmrc/teamsandrepositories/controller/JenkinsControllerSpec.scala
+++ b/test/uk/gov/hmrc/teamsandrepositories/controller/JenkinsControllerSpec.scala
@@ -28,6 +28,8 @@ import uk.gov.hmrc.teamsandrepositories.services.JenkinsService
 
 import scala.concurrent.Future
 
+import scala.concurrent.ExecutionContext.Implicits.global
+
 class JenkinsControllerSpec extends AnyWordSpec with Matchers with Results with MockitoSugar {
 
   val mockJenkinsService = mock[JenkinsService]

--- a/test/uk/gov/hmrc/teamsandrepositories/services/InitialDelayCalculatorSpec.scala
+++ b/test/uk/gov/hmrc/teamsandrepositories/services/InitialDelayCalculatorSpec.scala
@@ -22,7 +22,6 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.duration._
-import scala.language.postfixOps
 
 class InitialDelayCalculatorSpec extends AnyFreeSpec with Matchers {
 


### PR DESCRIPTION
To ensure the Controller always remains responsive, the Controller will use the injected fork-join-executor execution context. Where as the schedulers will use a fixed thread-pool as defined in configuration. All services/repositories will use the execution context as provided to them.