### PR TITLE
adding an explicit test for the added field.

### DIFF
--- a/test/uk/gov/hmrc/teamsandrepositories/controller/RepositoriesControllerSpec.scala
+++ b/test/uk/gov/hmrc/teamsandrepositories/controller/RepositoriesControllerSpec.scala
@@ -481,6 +481,13 @@ class RepositoriesControllerSpec
         "repo-name"
       )
     }
+
+    "return all the default branches of repositories" in new Setup {
+      val result       = controller.repositories(None)(FakeRequest())
+      val resultJson   = contentAsJson(result)
+      val repositories = resultJson.as[Seq[Repository]]
+      repositories.map(_.defaultBranch).distinct mustBe List("main")
+    }
   }
 
   private def nameField(obj: JsValue): String =


### PR DESCRIPTION
we did have tests for this endpoint. The tests do:

- hard coded instance of data.
- get mocked controller to return the mocked data
- check that the result contains the expected data.

which is more of a check about the controller using its dependency, rather than a serialisation test. I couldn't find any similar serialisation test so I just duplicated one for the repo names. 