### PR TITLE
BDOG-1581 Do not surface branch protection policies

### DIFF
--- a/app/uk/gov/hmrc/teamsandrepositories/GitRepository.scala
+++ b/app/uk/gov/hmrc/teamsandrepositories/GitRepository.scala
@@ -20,7 +20,6 @@ import java.time.Instant
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats
-import uk.gov.hmrc.teamsandrepositories.connectors.GhBranchProtection
 
 case class GitRepository(
   name              : String,
@@ -35,7 +34,6 @@ case class GitRepository(
   language          : Option[String],
   isArchived        : Boolean,
   defaultBranch     : String,
-  branchProtection  : Option[GhBranchProtection] = None
 )
 
 object GitRepository {
@@ -54,7 +52,6 @@ object GitRepository {
     ~ (__ \ "language"          ).formatNullable[String]
     ~ (__ \ "archived"          ).formatWithDefault[Boolean](false)
     ~ (__ \ "defaultBranch"     ).format[String]
-    ~ (__ \ "branchProtection"  ).formatNullable(GhBranchProtection.format)
     )(apply _, unlift(unapply))
   }
 
@@ -73,7 +70,6 @@ object GitRepository {
     ~ (__ \ "language"          ).formatNullable[String]
     ~ (__ \ "archived"          ).formatWithDefault[Boolean](false)
     ~ (__ \ "defaultBranch"     ).formatWithDefault[String]("master")
-    ~ (__ \ "branchProtection"  ).formatNullable(GhBranchProtection.format)
     )(apply _, unlift(unapply))
   }
 

--- a/app/uk/gov/hmrc/teamsandrepositories/connectors/GithubConnector.scala
+++ b/app/uk/gov/hmrc/teamsandrepositories/connectors/GithubConnector.scala
@@ -186,11 +186,6 @@ object GithubConnector {
       isArchived
       defaultBranchRef {
         name
-        branchProtectionRule {
-          requiresApprovingReviews
-          dismissesStaleReviews
-          requiresCommitSignatures
-        }
       }
       repositoryYaml: object(expression: "HEAD:repository.yaml") {
         ... on Blob {
@@ -302,7 +297,6 @@ case class GhRepository(
   language          : Option[String],
   isArchived        : Boolean,
   defaultBranch     : String,
-  branchProtection  : Option[GhBranchProtection],
   repositoryYamlText: Option[String],
   repoTypeHeuristics: RepoTypeHeuristics
 ) {
@@ -330,8 +324,7 @@ case class GhRepository(
       owningTeams        = manifestDetails.owningTeams,
       language           = language,
       isArchived         = isArchived,
-      defaultBranch      = defaultBranch,
-      branchProtection   = branchProtection
+      defaultBranch      = defaultBranch
     )
   }
 }
@@ -442,7 +435,6 @@ object GhRepository {
     ~ (__ \ "primaryLanguage" \ "name"                 ).readNullable[String]
     ~ (__ \ "isArchived"                               ).read[Boolean]
     ~ (__ \ "defaultBranchRef" \ "name"                ).readWithDefault("main")
-    ~ (__ \ "defaultBranchRef" \ "branchProtectionRule").readNullable(GhBranchProtection.format)
     ~ (__ \ "repositoryYaml" \ "text"                  ).readNullable[String]
     ~ RepoTypeHeuristics.reads
     )(apply _)
@@ -495,19 +487,4 @@ object RateLimit {
       logger.error("=== Api abuse detected ===", e)
       Future.failed(ApiAbuseDetectedException(e))
   }
-}
-
-final case class GhBranchProtection(
-  requiresApprovingReviews: Boolean,
-  dismissesStaleReviews: Boolean,
-  requiresCommitSignatures: Boolean
-)
-
-object GhBranchProtection {
-
-  val format: Format[GhBranchProtection] =
-    ( (__ \ "requiresApprovingReviews").format[Boolean]
-    ~ (__ \ "dismissesStaleReviews"   ).format[Boolean]
-    ~ (__ \ "requiresCommitSignatures").format[Boolean]
-    )(apply _, unlift(unapply))
 }

--- a/app/uk/gov/hmrc/teamsandrepositories/controller/model/RepositoryDetails.scala
+++ b/app/uk/gov/hmrc/teamsandrepositories/controller/model/RepositoryDetails.scala
@@ -22,7 +22,6 @@ import play.api.Logger
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 import uk.gov.hmrc.teamsandrepositories.config.UrlTemplates
-import uk.gov.hmrc.teamsandrepositories.connectors.GhBranchProtection
 import uk.gov.hmrc.teamsandrepositories.{GitRepository, RepoType}
 
 import scala.util.{Failure, Success, Try}
@@ -69,8 +68,7 @@ case class RepositoryDetails(
   environments    : Seq[Environment] = Seq.empty,
   language        : String,
   isArchived      : Boolean,
-  defaultBranch   : String,
-  branchProtection: Option[GhBranchProtection]
+  defaultBranch   : String
 )
 
 object RepositoryDetails {
@@ -94,7 +92,6 @@ object RepositoryDetails {
     ~ (__ \ "language"        ).format[String]
     ~ (__ \ "isArchived"      ).format[Boolean]
     ~ (__ \ "defaultBranch"   ).format[String]
-    ~ (__ \ "branchProtection").formatNullable(GhBranchProtection.format)
     )(apply, unlift(unapply))
   }
 
@@ -112,8 +109,7 @@ object RepositoryDetails {
         githubUrl        = Link("github-com", "GitHub.com", repo.url),
         language         = repo.language.getOrElse(""),
         isArchived       = repo.isArchived,
-        defaultBranch    = repo.defaultBranch,
-        branchProtection = repo.branchProtection
+        defaultBranch    = repo.defaultBranch
       )
 
     repo.repoType match {

--- a/test/uk/gov/hmrc/teamsandrepositories/connectors/GithubConnectorSpec.scala
+++ b/test/uk/gov/hmrc/teamsandrepositories/connectors/GithubConnectorSpec.scala
@@ -158,12 +158,7 @@ class GithubConnectorSpec
          },
          "isArchived": false,
          "defaultBranchRef": {
-           "name": "b1",
-           "branchProtectionRule": {
-             "requiresApprovingReviews": true,
-             "dismissesStaleReviews": true,
-             "requiresCommitSignatures": true
-           }
+           "name": "b1"
          }
        },
        {
@@ -180,12 +175,7 @@ class GithubConnectorSpec
          },
          "isArchived": true,
          "defaultBranchRef": {
-           "name": "b2",
-           "branchProtectionRule": {
-             "requiresApprovingReviews": true,
-             "dismissesStaleReviews": true,
-             "requiresCommitSignatures": true
-           }
+           "name": "b2"
          }
        }
     ]"""
@@ -295,7 +285,6 @@ class GithubConnectorSpec
         language           = Some("l1"),
         isArchived         = false,
         defaultBranch      = "b1",
-        branchProtection   = Some(GhBranchProtection(requiresApprovingReviews = true, dismissesStaleReviews = true, requiresCommitSignatures = true)),
         repositoryYamlText = None,
         repoTypeHeuristics = dummyRepoTypeHeuristics
       ),
@@ -310,7 +299,6 @@ class GithubConnectorSpec
         language           = Some("l2"),
         isArchived         = true,
         defaultBranch      = "b2",
-        branchProtection   = Some(GhBranchProtection(requiresApprovingReviews = true, dismissesStaleReviews = true, requiresCommitSignatures = true)),
         repositoryYamlText = None,
         repoTypeHeuristics = dummyRepoTypeHeuristics
       ),
@@ -325,7 +313,6 @@ class GithubConnectorSpec
         language           = None,
         isArchived         = false,
         defaultBranch      = "b3",
-        branchProtection   = None,
         repositoryYamlText = None,
         repoTypeHeuristics = dummyRepoTypeHeuristics
       )
@@ -543,7 +530,6 @@ class GithubConnectorSpec
       language           = Some("l1"),
       isArchived         = false,
       defaultBranch      = "b1",
-      branchProtection   = None,
       repositoryYamlText = None,
       repoTypeHeuristics = dummyRepoTypeHeuristics
     )

--- a/test/uk/gov/hmrc/teamsandrepositories/services/GithubV3RepositoryDataSourceSpec.scala
+++ b/test/uk/gov/hmrc/teamsandrepositories/services/GithubV3RepositoryDataSourceSpec.scala
@@ -91,7 +91,6 @@ class GithubV3RepositoryDataSourceSpec
       language           = Some("Scala"),
       isArchived         = false,
       defaultBranch      = "main",
-      branchProtection   = None,
       repositoryYamlText = None,
       repoTypeHeuristics = dummyRepoTypeHeuristics
     )
@@ -127,7 +126,6 @@ class GithubV3RepositoryDataSourceSpec
         language           = Some("Scala"),
         isArchived         = false,
         defaultBranch      = "main",
-        branchProtection   = None,
         repositoryYamlText = None,
         repoTypeHeuristics = dummyRepoTypeHeuristics
       )
@@ -142,7 +140,6 @@ class GithubV3RepositoryDataSourceSpec
         language           = Some("Scala"),
         isArchived         = false,
         defaultBranch      = "main",
-        branchProtection   = None,
         repositoryYamlText = None,
         repoTypeHeuristics = dummyRepoTypeHeuristics
       )
@@ -202,7 +199,6 @@ class GithubV3RepositoryDataSourceSpec
             language           = Some("Scala"),
             isArchived         = false,
             defaultBranch      = "main",
-            branchProtection   = None,
             repositoryYamlText = None,
             repoTypeHeuristics = dummyRepoTypeHeuristics
           ),
@@ -217,7 +213,6 @@ class GithubV3RepositoryDataSourceSpec
             language           = Some("Scala"),
             isArchived         = false,
             defaultBranch      = "main",
-            branchProtection   = None,
             repositoryYamlText = None,
             repoTypeHeuristics = dummyRepoTypeHeuristics
           )
@@ -845,7 +840,6 @@ class GithubV3RepositoryDataSourceSpec
           language           = Some("Scala"),
           isArchived         = false,
           defaultBranch      = "main",
-          branchProtection   = None,
           repositoryYamlText = None,
           repoTypeHeuristics = dummyRepoTypeHeuristics
         )

--- a/test/uk/gov/hmrc/teamsandrepositories/services/PersistingServiceSpec.scala
+++ b/test/uk/gov/hmrc/teamsandrepositories/services/PersistingServiceSpec.scala
@@ -25,7 +25,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import play.api.Configuration
 import uk.gov.hmrc.teamsandrepositories.{GitRepository, TeamRepositories}
 import uk.gov.hmrc.teamsandrepositories.config.GithubConfig
-import uk.gov.hmrc.teamsandrepositories.connectors.{GhBranchProtection, GhTeam, GithubConnector}
+import uk.gov.hmrc.teamsandrepositories.connectors.{GhTeam, GithubConnector}
 import uk.gov.hmrc.teamsandrepositories.persistence.TeamsAndReposPersister
 
 import scala.concurrent.Future
@@ -62,8 +62,7 @@ class PersistingServiceSpec
               lastActiveDate   = now,
               language         = Some("Scala"),
               isArchived       = false,
-              defaultBranch    = "main",
-              branchProtection = Some(GhBranchProtection(requiresApprovingReviews = true, dismissesStaleReviews = true, requiresCommitSignatures = true))
+              defaultBranch    = "main"
             ),
             GitRepository(
               name           = "repo2",


### PR DESCRIPTION
We've decided not to pursue this method of surfacing branch protection policies as doing so would require `teams-and-repositories` having admin access to all repositories in the organisation.

See [here](https://github.community/t/user-cannot-access-branch-protection-endpoint-via-api/14612/3) and [here](https://hmrcdigital.slack.com/archives/C86M80NBX/p1644505538212039) for more context.