### PR TITLE
BDOG-3638: Update dependencies

### DIFF
--- a/app/uk/gov/hmrc/teamsandrepositories/connector/SlackNotificationsConnector.scala
+++ b/app/uk/gov/hmrc/teamsandrepositories/connector/SlackNotificationsConnector.scala
@@ -46,7 +46,7 @@ class SlackNotificationsConnector @Inject()(
     given OWrites[SlackNotificationRequest] = SlackNotificationRequest.writes
     given Reads[SlackNotificationResponse] = SlackNotificationResponse.reads
     httpClientV2
-      .post(url"$url/slack-notifications/v2/notification")
+      .post(url"$url/api/v2/notification")
       .withBody(Json.toJson(message))
       .setHeader("Authorization" -> internalAuthToken)
       .execute[SlackNotificationResponse]

--- a/app/uk/gov/hmrc/teamsandrepositories/connector/SlackNotificationsConnector.scala
+++ b/app/uk/gov/hmrc/teamsandrepositories/connector/SlackNotificationsConnector.scala
@@ -46,7 +46,7 @@ class SlackNotificationsConnector @Inject()(
     given OWrites[SlackNotificationRequest] = SlackNotificationRequest.writes
     given Reads[SlackNotificationResponse] = SlackNotificationResponse.reads
     httpClientV2
-      .post(url"$url/api/v2/notification")
+      .post(url"$url/slack-notifications/v2/notification")
       .withBody(Json.toJson(message))
       .setHeader("Authorization" -> internalAuthToken)
       .execute[SlackNotificationResponse]

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -9,7 +9,7 @@ object AppDependencies {
     ws,
     "uk.gov.hmrc"            %% "bootstrap-backend-play-30"    % bootstrapPlayVersion,
     "uk.gov.hmrc.mongo"      %% "hmrc-mongo-metrix-play-30"    % hmrcMongoVersion,
-    "uk.gov.hmrc"            %% "internal-auth-client-play-30" % "4.3.0",
+    "uk.gov.hmrc"            %% "internal-auth-client-play-30" % "4.4.0",
     "org.yaml"               %  "snakeyaml"                    % "2.3",
     "org.typelevel"          %% "cats-core"                    % "2.13.0",
     "software.amazon.awssdk" %  "sqs"                          % "2.31.43"


### PR DESCRIPTION
Originally this PR was for updating Legacy URLs but after learning that /api prefix is not used here because it is an internally routed app - I backed out the URL changes.

As I was here, I am leaving this PR in place to bump the dependencies for `auth-client`